### PR TITLE
drivers: pn547: fix missing print param and remove unused label

### DIFF
--- a/drivers/misc/pn547.c
+++ b/drivers/misc/pn547.c
@@ -474,7 +474,8 @@ static int pn547_probe(struct i2c_client *client,
 	if (gpio_is_valid(platform_data->pvdd_en_gpio)) {
 		ret = gpio_request(platform_data->pvdd_en_gpio, "nfc_pvdd_en");
 		if (ret)
-			pr_warn("%s: Failed to request nfc_pvdd_en GPIO\n");
+			pr_warn("%s: Failed to request nfc_pvdd_en GPIO\n",
+					__func__);
 	}
 
 	pn547_dev = kzalloc(sizeof(*pn547_dev), GFP_KERNEL);
@@ -622,7 +623,6 @@ err_get_clock:
 #endif
 	kfree(pn547_dev);
 err_exit:
-err_pvdd_en:
 	gpio_free(platform_data->pvdd_en_gpio);
 #ifdef CONFIG_NFC_PN547_CLOCK_REQUEST
 	gpio_free(platform_data->clk_req_gpio);


### PR DESCRIPTION
drivers/misc/pn547.c:477:4: warning: format '%s' expects a matching 'char *' argument [-Wformat=]
    pr_warn("%s: Failed to request nfc_pvdd_en GPIO\n");
    ^
drivers/misc/pn547.c:625:1: warning: label 'err_pvdd_en' defined but not used [-Wunused-label]

Change-Id: Ia7d4220e50a1185e21f45bc76059b617a8e5d1a1
